### PR TITLE
Use prometheus/common/version for versioning and exposing metric

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GOTOOLS=github.com/mitchellh/gox/...
 
 NAME=cloudmonitor_exporter
 
-VERSION=0.1.5
+VERSION=0.1.6
 COMMIT=$(shell git rev-parse HEAD)
 BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 BUILDER=$(shell whoami)@$(shell hostname)

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,16 @@ GOTOOLS=github.com/mitchellh/gox/...
 NAME=cloudmonitor_exporter
 
 VERSION=0.1.5
-BUILD_TIME=`date '+%F-%T%z'`
-
-LDFLAGS=-ldflags "-X main.version=${VERSION} -X main.buildtime=${BUILD_TIME}"
+COMMIT=$(shell git rev-parse HEAD)
+BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
+BUILDER=$(shell whoami)@$(shell hostname)
+BUILD_DATE=$(shell date '+%F-%T%z')
+VERSION_PATH=github.com/ExpressenAB/cloudmonitor_exporter/vendor/github.com/prometheus/common/version
+LDFLAGS=-ldflags "-X ${VERSION_PATH}.Version=${VERSION} \
+                  -X ${VERSION_PATH}.Revision=${COMMIT} \
+                  -X ${VERSION_PATH}.Branch=${BRANCH} \
+                  -X ${VERSION_PATH}.BuildUser=${BUILDER} \
+                  -X ${VERSION_PATH}.BuildDate=${BUILD_DATE}"
 
 all: tools build
 

--- a/cloudmonitor_exporter.go
+++ b/cloudmonitor_exporter.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"github.com/avct/user-agent-surfer"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/version"
 	"log"
 	"net"
 	"net/http"
@@ -16,11 +17,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-)
-
-var (
-	version   string
-	buildtime string
 )
 
 var (
@@ -540,7 +536,7 @@ func main() {
 
 	flag.Parse()
 
-	log.Printf("Cloudmonitor-exporter v%s\n", version+"("+buildtime+")")
+	log.Printf("Cloudmonitor-exporter %s\n", version.Print("cloudmonitor_exporter"))
 	if *showVersion {
 		return
 	}
@@ -552,6 +548,7 @@ func main() {
 		log.Printf("logging to %s", *accesslog)
 	}
 
+	prometheus.MustRegister(version.NewCollector("cloudmonitor_exporter"))
 	prometheus.MustRegister(exporter)
 
 	http.Handle(*metricsEndpoint, prometheus.Handler())

--- a/vendor/github.com/prometheus/common/version/info.go
+++ b/vendor/github.com/prometheus/common/version/info.go
@@ -1,0 +1,89 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"bytes"
+	"fmt"
+	"runtime"
+	"strings"
+	"text/template"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Build information. Populated at build-time.
+var (
+	Version   string
+	Revision  string
+	Branch    string
+	BuildUser string
+	BuildDate string
+	GoVersion = runtime.Version()
+)
+
+// NewCollector returns a collector which exports metrics about current version information.
+func NewCollector(program string) *prometheus.GaugeVec {
+	buildInfo := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: program,
+			Name:      "build_info",
+			Help: fmt.Sprintf(
+				"A metric with a constant '1' value labeled by version, revision, branch, and goversion from which %s was built.",
+				program,
+			),
+		},
+		[]string{"version", "revision", "branch", "goversion"},
+	)
+	buildInfo.WithLabelValues(Version, Revision, Branch, GoVersion).Set(1)
+	return buildInfo
+}
+
+// versionInfoTmpl contains the template used by Info.
+var versionInfoTmpl = `
+{{.program}}, version {{.version}} (branch: {{.branch}}, revision: {{.revision}})
+  build user:       {{.buildUser}}
+  build date:       {{.buildDate}}
+  go version:       {{.goVersion}}
+`
+
+// Print returns version information.
+func Print(program string) string {
+	m := map[string]string{
+		"program":   program,
+		"version":   Version,
+		"revision":  Revision,
+		"branch":    Branch,
+		"buildUser": BuildUser,
+		"buildDate": BuildDate,
+		"goVersion": GoVersion,
+	}
+	t := template.Must(template.New("version").Parse(versionInfoTmpl))
+
+	var buf bytes.Buffer
+	if err := t.ExecuteTemplate(&buf, "version", m); err != nil {
+		panic(err)
+	}
+	return strings.TrimSpace(buf.String())
+}
+
+// Info returns version, branch and revision information.
+func Info() string {
+	return fmt.Sprintf("(version=%s, branch=%s, revision=%s)", Version, Branch, Revision)
+}
+
+// BuildContext returns goVersion, buildUser and buildDate information.
+func BuildContext() string {
+	return fmt.Sprintf("(go=%s, user=%s, date=%s)", GoVersion, BuildUser, BuildDate)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -57,6 +57,12 @@
 			"revisionTime": "2017-02-20T10:38:46Z"
 		},
 		{
+			"checksumSHA1": "91KYK0SpvkaMJJA2+BcxbVnyRO0=",
+			"path": "github.com/prometheus/common/version",
+			"revision": "bc8b88226a1210b016e9993b1d75f858c9c8f778",
+			"revisionTime": "2017-08-30T19:05:55Z"
+		},
+		{
 			"checksumSHA1": "cD4xn1qxbkiuXqUExpdnDroCTrY=",
 			"path": "github.com/prometheus/procfs",
 			"revision": "a1dba9ce8baed984a2495b658c82687f8157b98f",
@@ -69,5 +75,5 @@
 			"revisionTime": "2017-02-16T22:32:56Z"
 		}
 	],
-	"rootPath": "cloudmonitor_exporter"
+	"rootPath": "github.com/ExpressenAB/cloudmonitor_exporter"
 }


### PR DESCRIPTION
This PR adds prometheus/common/version for exposing the version info in a manner consistent with other parts of the Prometheus ecosystem. This also adds a new metric which can be used to track the version in use in Prometheus.