### PR TITLE
Change method error to correct http status

### DIFF
--- a/cloudmonitor_exporter.go
+++ b/cloudmonitor_exporter.go
@@ -426,7 +426,7 @@ func getIPVersion(ip_s string) string {
 
 func (e *Exporter) HandleCollectorPost(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
-		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		http.Error(w, "Internal server error", http.StatusMethodNotAllowed)
 		return
 	}
 


### PR DESCRIPTION
There is a dedicated http status for using the wrong method, this PR changes to that.

https://http.cat/405