### PR TITLE
Update docker-compose code documentation to match recent evolutions of tools

### DIFF
--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -10,7 +10,9 @@ Docker-compose can be used to setup an small stack with prometheus/grafana/hapro
 `git clone https://github.com/ExpressenAB/cloudmonitor_exporter.git`
 * Create self-signed certificate by running setup.sh
 ```
-> cd cloudmonitor_exporter/setup
+> cd cloudmonitor_exporter
+> make docker
+> cd setup
 > ./setup.sh
 This will generate a self-signed certificate to use with cloudmonitor_exporter
 Enter companyname for certificate:

--- a/setup/docker-compose.yml
+++ b/setup/docker-compose.yml
@@ -1,7 +1,8 @@
-version: '2'
+---
+version: '3'
 volumes:
-    prometheus_data: {}
-    grafana_data: {}
+  prometheus_data: {}
+  grafana_data: {}
 
 services:
   prometheus:
@@ -11,15 +12,15 @@ services:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
       - ./prometheus_data:/prometheus
     command:
-      - '-config.file=/etc/prometheus/prometheus.yml'
-      - '-storage.local.path=/prometheus'
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
     expose:
       - 9090
     links:
       - cloudmonitor:cloudmonitor
     ports:
       - 9090:9090
-  
+
   grafana:
     image: grafana/grafana
     depends_on:
@@ -47,5 +48,4 @@ services:
     expose:
       - 9143
     ports:
-     - "9143:9143"
-
+      - "9143:9143"


### PR DESCRIPTION
It's required to run the make command before starting docker-compose.
Otherwise, we fall on error: 
```
cloudmonitor_exporter/setup] % docker-compose up
Building cloudmonitor
Step 1/5 : FROM alpine:latest
 ---> a24bb4013296
Step 2/5 : ARG VERSION=0.0.0
 ---> Using cache
 ---> 9fd830dc2608
Step 3/5 : COPY "build/cloudmonitor_exporter_${VERSION}_linux_amd64/cloudmonitor_exporter" "/app/cloudmonitor_exporter"
ERROR: Service 'cloudmonitor' failed to build : COPY failed: stat /var/lib/docker/tmp/docker-builder383533461/build/cloudmonitor_exporter_0.0.0_linux_amd64/cloudmonitor_exporter: no such file or directory
```